### PR TITLE
Resolved JSON Circular Structure Error in case of error.

### DIFF
--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -4,6 +4,7 @@ import Cluster, { TaskFunction } from './Cluster';
 import { WorkerBrowserInstance, ContextInstance } from './browser/AbstractBrowser';
 import { Page } from 'puppeteer';
 import { timeoutExecute, debugGenerator, log } from './util';
+import { inspect } from 'util';
 
 const debug = debugGenerator('Worker');
 
@@ -73,7 +74,7 @@ export default class Worker implements WorkerOptions {
 
         page.on('error', (err) => {
             errorState = err;
-            log('Error (page error) crawling ' + JSON.stringify(job.data)
+            log('Error (page error) crawling ' + inspect(job.data)
                 + ' // message: ' + err.message);
         });
 
@@ -90,13 +91,13 @@ export default class Worker implements WorkerOptions {
             );
         } catch (err) {
             errorState = err;
-            log('Error crawling ' + JSON.stringify(job.data) + ' // message: ' + err.message);
+            log('Error crawling ' + inspect(job.data) + ' // message: ' + err.message);
         }
 
         try {
             await timeoutExecute(BROWSER_TIMEOUT, browserInstance.close());
         } catch (e) {
-            debug('Error closing browser instance for ' + + JSON.stringify(job.data)
+            debug('Error closing browser instance for ' + inspect(job.data)
                 + ': ' + e.message);
             await this.browser.repair();
         }


### PR DESCRIPTION
In case of an error scenario while executing `Task` with complex objects like `request` and `response` of `expressjs` as data, the framework crashes because of a `JSON Circular Structure Error` when logging the data.

To fix this, have used inspect function from Node's `util` library so there is the whole dump written to the logs as well.

Also, the `package.json` needs an update too as there were version updates available for a few libraries.